### PR TITLE
Adds a reference to the xcode project

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Node.js v7.1.0 (with V8, not JavaScriptCore) was compiled to a binary `bin_node_
 
 #### What about iOS support?
 
-We can't run V8 Node.js on iOS since that violates Apple's policy around Just-In-Time compilation, but ChakraCore Node.js can run on iOS. We are depending on [this project by Janea Systems](http://www.janeasystems.com/blog/node-js-meets-ios/) to open source their methods and include a proper open source license.
+We can't run V8 Node.js on iOS since that violates Apple's policy around Just-In-Time compilation, but ChakraCore Node.js can run on iOS. We are depending on [this project by Janea Systems](http://www.janeasystems.com/blog/node-js-meets-ios/) to open source their methods and include a proper open source license. Also it exists the possibility of using [jxcore](https://github.com/jxcore/jxcore) which I believe is more permissive.
 
 #### Does it support packages with native bindings?
 


### PR DESCRIPTION
Hi,

I have been recently researched the possibility of packing the jxcore-cordova APIs to react-native, just this past days and stumbled upon this. I have to thank you a lot for the work you've done, and wanted to create an issue to add some information about my own findings.

I would like to help as far as I could contribute to your work, using jxcore-chackra to add iOS support, but don't know how much time I can commit.

Thanks a lot and sorry for the little-bit-too-much of a PR to comment this out.